### PR TITLE
Github Actionsでテストする

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: setup ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby_version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,9 +41,7 @@ jobs:
       - name: bundle install
         env:
           RAILS_VERSION: ${{ matrix.rails_version }}
-        run: |
-          gem install bundler
-          bundle install
+        run: bundle install --retry=3 --jobs=3
 
       - name: run rspec
         run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: run rspec
+on:
+  - push
+jobs:
+  test:
+    strategy:
+      matrix:
+        rails_version:
+          - ~>5.1.0
+          - ~>5.2.0
+          - ~>6.0.0
+          - ~>6.1.0
+        ruby_version:
+          - 2.4
+          - 2.5
+          - 2.6
+          - 2.7
+        exclude:
+          - rails_version: ~>6.0.0
+            ruby_version: 2.4
+          - rails_version: ~>6.1.0
+            ruby_version: 2.4
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: setup ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+
+      - name: bundle install
+        env:
+          RAILS_VERSION: ${{ matrix.rails_version }}
+        run: |
+          gem install bundler
+          bundle install
+
+      - name: run rspec
+        run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: run rspec
 on:
-  - push
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 jobs:
   test:
     strategy:

--- a/inum.gemspec
+++ b/inum.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_development_dependency 'bundler', '~> 1.5'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '>= 3.0.0'
   spec.add_development_dependency 'yard'


### PR DESCRIPTION
初めまして。

Inum gem使わせていただいています。

TravisCIが近日中にサービスを終了しそう & Ruby, Railsともに最近のパーションでテストされていないことに気付き、Github ActionsでCIする設定を雑ですが書きましたので、よろしければご査収ください。

- 使用している https://github.com/actions/setup-ruby がRubyの2.4から2.7までしか対応していなかったため、2.3以前と最新の3.0は入れていません。
- [Rails5.0.0もrspec外でエラーが起きてなぜか通らなかった](https://github.com/takayamaki/inum/actions/runs/462949999)のですが、通らない原因の究明をする手間が面倒だったし5.0系を今頑張ってテストするメリットは薄そうなのでテスト対象のRailsバージョンは5.1系以降にしました